### PR TITLE
Change context menu register timing from onInstall to onStartup

### DIFF
--- a/src/js/main.js
+++ b/src/js/main.js
@@ -1,4 +1,4 @@
-chrome.runtime.onInstalled.addListener(
+chrome.runtime.onStartup.addListener(
   function() {
     var menuId = chrome.contextMenus.create({
       type: 'normal',


### PR DESCRIPTION
The context menu isn't showing up once you quit Chrome after installation; fixed
